### PR TITLE
 Add Python 3 support and drop support to Python 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,11 @@ lib64/
 parts/
 sdist/
 var/
+bin/
 *.egg-info/
 .installed.cfg
 *.egg
+/pyvenv.cfg
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -52,3 +54,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.settings
+.*project

--- a/norecaptcha/captcha.py
+++ b/norecaptcha/captcha.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import urllib
 
+
 try:
     import json
 except ImportError:
@@ -17,25 +18,20 @@ VERIFY_SERVER = "www.google.com"
 
 
 class RecaptchaResponse(object):
-
     def __init__(self, is_valid, error_code=None):
         self.is_valid = is_valid
         self.error_code = error_code
 
     def __repr__(self):
-        return "Recaptcha response: %s %s" % (
-            self.is_valid, self.error_code)
+        return "Recaptcha response: %s %s" % (self.is_valid, self.error_code)
 
     def __str__(self):
         return self.__repr__()
 
 
-def displayhtml(site_key,
-                language='',
-                theme='light',
-                fallback=False,
-                d_type='image',
-                size='normal'):
+def displayhtml(
+    site_key, language="", theme="light", fallback=False, d_type="image", size="normal"
+):
     """
     Gets the HTML to display for reCAPTCHA
 
@@ -86,19 +82,16 @@ def displayhtml(site_key,
   </div>
 </noscript>
 """ % {
-        'LanguageCode': language,
-        'SiteKey': site_key,
-        'Theme': theme,
-        'Type': d_type,
-        'Size': size,
-        'Fallback': fallback,
+        "LanguageCode": language,
+        "SiteKey": site_key,
+        "Theme": theme,
+        "Type": d_type,
+        "Size": size,
+        "Fallback": fallback,
     }
 
 
-def submit(recaptcha_response_field,
-           secret_key,
-           remoteip,
-           verify_server=VERIFY_SERVER):
+def submit(recaptcha_response_field, secret_key, remoteip, verify_server=VERIFY_SERVER):
     """
     Submits a reCAPTCHA request for verification. Returns RecaptchaResponse
     for the request
@@ -109,29 +102,28 @@ def submit(recaptcha_response_field,
     """
 
     if not (recaptcha_response_field and len(recaptcha_response_field)):
-        return RecaptchaResponse(
-            is_valid=False,
-            error_code='incorrect-captcha-sol'
-        )
+        return RecaptchaResponse(is_valid=False, error_code="incorrect-captcha-sol")
 
     def encode_if_necessary(s):
         if isinstance(s, unicode):
-            return s.encode('utf-8')
+            return s.encode("utf-8")
         return s
 
-    params = urllib.urlencode({
-        'secret': encode_if_necessary(secret_key),
-        'remoteip': encode_if_necessary(remoteip),
-        'response': encode_if_necessary(recaptcha_response_field),
-    })
+    params = urllib.urlencode(
+        {
+            "secret": encode_if_necessary(secret_key),
+            "remoteip": encode_if_necessary(remoteip),
+            "response": encode_if_necessary(recaptcha_response_field),
+        }
+    )
 
     request = Request(
         url="https://%s/recaptcha/api/siteverify" % verify_server,
         data=params,
         headers={
             "Content-type": "application/x-www-form-urlencoded",
-            "User-agent": "noReCAPTCHA Python"
-        }
+            "User-agent": "noReCAPTCHA Python",
+        },
     )
 
     httpresp = urlopen(request)
@@ -139,13 +131,10 @@ def submit(recaptcha_response_field,
     return_values = json.loads(httpresp.read())
     httpresp.close()
 
-    return_code = return_values['success']
-    error_codes = return_values.get('error-codes', [])
+    return_code = return_values["success"]
+    error_codes = return_values.get("error-codes", [])
 
     if return_code:
         return RecaptchaResponse(is_valid=True)
     else:
-        return RecaptchaResponse(
-            is_valid=False,
-            error_code=error_codes
-        )
+        return RecaptchaResponse(is_valid=False, error_code=error_codes)

--- a/norecaptcha/captcha.py
+++ b/norecaptcha/captcha.py
@@ -1,17 +1,7 @@
-# -*- coding: utf-8 -*-
-import urllib
-
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
-try:
-    # test if it's Python 3
-    from urllib.request import Request, urlopen
-except:
-    from urllib2 import Request, urlopen
+from json import loads
+from urllib.parse import urlencode
+from urllib.request import Request
+from urllib.request import urlopen
 
 
 VERIFY_SERVER = "www.google.com"
@@ -104,18 +94,13 @@ def submit(recaptcha_response_field, secret_key, remoteip, verify_server=VERIFY_
     if not (recaptcha_response_field and len(recaptcha_response_field)):
         return RecaptchaResponse(is_valid=False, error_code="incorrect-captcha-sol")
 
-    def encode_if_necessary(s):
-        if isinstance(s, unicode):
-            return s.encode("utf-8")
-        return s
-
-    params = urllib.urlencode(
+    params = urlencode(
         {
-            "secret": encode_if_necessary(secret_key),
-            "remoteip": encode_if_necessary(remoteip),
-            "response": encode_if_necessary(recaptcha_response_field),
+            "secret": secret_key,
+            "remoteip": remoteip,
+            "response": recaptcha_response_field,
         }
-    )
+    ).encode()
 
     request = Request(
         url="https://%s/recaptcha/api/siteverify" % verify_server,
@@ -128,7 +113,7 @@ def submit(recaptcha_response_field, secret_key, remoteip, verify_server=VERIFY_
 
     httpresp = urlopen(request)
 
-    return_values = json.loads(httpresp.read())
+    return_values = loads(httpresp.read())
     httpresp.close()
 
     return_code = return_values["success"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
-
 from os import path
+
 
 README = path.abspath(path.join(path.dirname(__file__), "README.md"))
 
@@ -22,7 +22,10 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Internet",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,27 +2,27 @@ from distutils.core import setup
 
 from os import path
 
-README = path.abspath(path.join(path.dirname(__file__), 'README.md'))
+README = path.abspath(path.join(path.dirname(__file__), "README.md"))
 
 setup(
-   name='norecaptcha',
-   version='0.3.0',
-   packages=['norecaptcha'],
-   description='Python client for the google new No CAPTCHA reCAPTCHA services.',
-   long_description=open(README).read(),
-   author='Oursky Ltd.',
-   author_email='rick.mak@gmail.com',
-   url='https://github.com/oursky/norecaptcha',
-   download_url='https://www.github.com/oursky/norecaptcha/tarball/master',
-   license='MIT',
-   classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Topic :: Internet',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+    name="norecaptcha",
+    version="0.3.0",
+    packages=["norecaptcha"],
+    description="Python client for the google new No CAPTCHA reCAPTCHA services.",
+    long_description=open(README).read(),
+    author="Oursky Ltd.",
+    author_email="rick.mak@gmail.com",
+    url="https://github.com/oursky/norecaptcha",
+    download_url="https://www.github.com/oursky/norecaptcha/tarball/master",
+    license="MIT",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Topic :: Internet",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
     ],
 )


### PR DESCRIPTION
In Python 3, the data parameter of the `Request` has to be a byte. So we need to use the `encode` method to transform the parameters into byte.